### PR TITLE
2026 fixes

### DIFF
--- a/libs/assimp/code/AssetLib/MMD/MMDPmxParser.h
+++ b/libs/assimp/code/AssetLib/MMD/MMDPmxParser.h
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
 
+#include <cstdint>
 #include <vector>
 #include <string>
 #include <iostream>

--- a/tools/remap/source/bspfile_shared.cpp
+++ b/tools/remap/source/bspfile_shared.cpp
@@ -163,7 +163,7 @@ void Shared::MakeMeshes(const entity_t &e) {
     }
 
     // Recalculate lightmapUVs for all vertices
-    Shared::MakeLightmapUVs();
+    // Shared::MakeLightmapUVs();  /* causes heap corruption */
 
     // Combine all meshes based on shaderInfo and AABB tests
     std::size_t index = 0;


### PR DESCRIPTION
Recently got MRVN to build on my machine.
Was planning to work on some new features.
But had to make the following fixes first:


## `libs/assimp/code/AssetLib/MMD/MMDPmxParser.h`

Breaks on GCC 13.2 and later.
This is because of changes to how standard library headers include each other.
See the [Official GCC Docs](https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes) for more info.


## `tools/remap/source/bspfile_shared.cpp`

Map compiles would break in `Shared::MakeLightmapUVs`
Specifically on the last line, inside `Sys_Printf`.

Took a long time to figure this one out/
Had to run map compiles in the terminal to get a `SIGSEGV` message.

Ran compiles w/ `gdb` (`gdb --args remap ...`) to get a stack trace.
`SIGSEGV` inside `malloc` indicated heap corruption.

So I used `valgrind`, which initially resulted in successful map compiles.
However, I switched to using the `--leak-check=full` & `--show-leak-kinds=all` args.
These gave a verbose breakdown of where memory leaks were occuring.

I commented out `Shared::MakeLightmapUVs` since it isn't essential atm
Will probably need a refactor in future anyway.

`.shader` parsing is responsible for far more memory leaks.
(meaning other users might not even encounter this bug, since I have a lot of `.shader`s)
But `Shared::MakeLightmapUVs` is my code, so I've got no problem muting it for now.


## tl;dr

I've got 2 small fixes that make MRVN run on my machine (2026 Arch Linux).
These bugs appear to be unique to MRVN on my machine.
(the `assimp` bug doesn't appear in upstream `assimp` or `netradiant-custom`)

Pushing these fixes lets me build & run MRVN on my machine.
Which should allow me to review PRs that require local testing.

Most of the active PRs MRVN has atm are pretty small.
Hoping to get them merged nice and quick before working on new features.