### PR TITLE
Fix gitignore on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@ windeps
 # Unix binary files
 *.so
 libassimp.*
-radiant
-remap
+install/radiant
+install/remap


### PR DESCRIPTION
`radiant` ignore meant to ignore the executable was ignoring the directory instead.