### PR TITLE
Replace quake spawns list with titanfall spawns

### DIFF
--- a/radiant/map.cpp
+++ b/radiant/map.cpp
@@ -441,11 +441,10 @@ Entity *Scene_FindPlayerStart(){
 	typedef const char* StaticString;
 	StaticString strings[] = {
 		"info_player_start",
-		"info_player_deathmatch",
-		"team_CTF_redplayer",
-		"team_CTF_blueplayer",
-		"team_CTF_redspawn",
-		"team_CTF_bluespawn",
+		"info_spawnpoint_human_start",
+		"info_spawnpoint_dropship_start",
+		"info_spawnpoint_titan_start",
+		"info_spawnpoint_droppod_start",
 	};
 	typedef const StaticString* StaticStringIterator;
 	for ( StaticStringIterator i = strings, end = strings + ( sizeof( strings ) / sizeof( StaticString ) ); i != end; ++i )


### PR DESCRIPTION
Replaces all the extra quake spawns with spawns actually used in titanfall. Two reasons i'm doing this is because:

1. None of those are ever used
2. This fixes an issue where MRVNs camera would spawn at 0 0 0 if the map didn't have any `info_player_start` entities. We should be using `info_spawnpoint_human_start` instead of `info_player_start` anyways, since the former is used basically everywhere and the game complains if the map doesn't have any

<img width="870" height="700" alt="Screenshot  2026-05-02 14_24_00" src="https://github.com/user-attachments/assets/8b19b47d-9b39-44eb-b99e-60b827d41bd7" />

<img width="1131" height="665" alt="image" src="https://github.com/user-attachments/assets/f86edf17-338e-4316-beb0-9ef25e82a7e9" />
