### PR TITLE
Spawn editor camera at eye level

### DIFF
--- a/radiant/map.cpp
+++ b/radiant/map.cpp
@@ -483,6 +483,7 @@ void Map_StartPosition(){
 
 	Vector3 origin;
 	if ( entity != nullptr && string_parse_vector3( entity->getKeyValue( "origin" ), origin ) ) {
+		origin[2] += 64
 		FocusViews( origin, string_read_float( entity->getKeyValue( "angle" ) ) );
 	}
 	else

--- a/radiant/map.cpp
+++ b/radiant/map.cpp
@@ -481,11 +481,9 @@ void Map_StartPosition(){
 	Entity* entity = Scene_FindPlayerStart();
 
 	Vector3 origin;
-	Vector3 angles;
 	if ( entity != nullptr && string_parse_vector3( entity->getKeyValue( "origin" ), origin ) ) {
 		origin[2] += 64;
-		angles = string_parse_vector3( entity->getKeyValue( "angles" ), angles );
-		FocusViews( origin, angles[1] );
+		FocusViews( origin, string_read_float( entity->getKeyValue( "angles" ) ) );
 	}
 	else
 	{

--- a/radiant/map.cpp
+++ b/radiant/map.cpp
@@ -483,7 +483,7 @@ void Map_StartPosition(){
 
 	Vector3 origin;
 	if ( entity != nullptr && string_parse_vector3( entity->getKeyValue( "origin" ), origin ) ) {
-		origin[2] += 64
+		origin[2] += 64;
 		FocusViews( origin, string_read_float( entity->getKeyValue( "angle" ) ) );
 	}
 	else

--- a/radiant/map.cpp
+++ b/radiant/map.cpp
@@ -483,7 +483,7 @@ void Map_StartPosition(){
 	Vector3 origin;
 	if ( entity != nullptr && string_parse_vector3( entity->getKeyValue( "origin" ), origin ) ) {
 		origin[2] += 64;
-		FocusViews( origin, string_read_float( entity->getKeyValue( "angle" ) ) );
+		FocusViews( origin, string_read_float( entity->getKeyValue( "angles" ) ) );
 	}
 	else
 	{

--- a/radiant/map.cpp
+++ b/radiant/map.cpp
@@ -481,9 +481,11 @@ void Map_StartPosition(){
 	Entity* entity = Scene_FindPlayerStart();
 
 	Vector3 origin;
+	Vector3 angles;
 	if ( entity != nullptr && string_parse_vector3( entity->getKeyValue( "origin" ), origin ) ) {
 		origin[2] += 64;
-		FocusViews( origin, string_read_float( entity->getKeyValue( "angles" ) ) );
+		angles = string_parse_vector3( entity->getKeyValue( "angles" ), angles );
+		FocusViews( origin, angles[1] );
 	}
 	else
 	{


### PR DESCRIPTION
Spawns the editor camera at eye level, though the beard from the `info_player_start` model will slightly block your view. I can increase the height some more if that's too annoying

Closes https://github.com/MRVN-Radiant/MRVN-Radiant/issues/17